### PR TITLE
Add trunk inertial

### DIFF
--- a/xml/aliengo.xml
+++ b/xml/aliengo.xml
@@ -53,6 +53,7 @@
 
 	<!-- trunk -->
         <body name="trunk" pos="0 0 1.4">
+            <inertial pos="0.008465 0.004045 -0.000763" quat="1 0 0 0" mass="9.041" diaginertia="0.033260231 0.16117211 0.17460442" />
             <freejoint name="root"/>
             <geom class="collision" size="0.3235 0.075 0.056" type="box" />
 	    <geom class="visual" mesh="trunk_mesh" />


### PR DESCRIPTION
@rohanpsingh Let me ask you two questions.

1. How was the `aliengo.xml` generated? (automatically converted from `aliengo.urdf` or manually copy-and-pasted?) If copi-and-paste, how did you calculate `quat` of `inertial`?
2. Some parameters do not consistent between xml and urdf as follows (mass is 0.267 in xml but 0.207 in urdf). Is this intentional or erroneous?
https://github.com/mmurooka/aliengo_mj_description/blob/84bbbc720e1059db8e984129ebef88acb501d89e/xml/aliengo.xml#L74
https://github.com/unitreerobotics/unitree_ros/blob/master/robots/aliengo_description/xacro/aliengo.urdf#L449
